### PR TITLE
fix pymongo autoreference bug in dbhelper

### DIFF
--- a/database/dbhelper.py
+++ b/database/dbhelper.py
@@ -12,9 +12,10 @@ class Database(object):
         max_pool = MONGODB_SETTINGS['max_pool']
         self.connection = pymongo.Connection(host, port, max_pool)
         self.db = self.connection["blade"]
+        self.db.add_son_manipulator(NamespaceInjector())
         self.db.add_son_manipulator(AutoReference(self.db))
 
-    def insert(self, table, documents): 
+    def insert(self, table, documents):
         return self.db[table].insert(documents)
 
     def query(self, table, parameters, sort, offset, limit, fields=None):


### PR DESCRIPTION
hi~我在写一个tornado的应用，谢谢你的代码，异常的简洁和清晰，好喜欢哇~~

我在看你的dbhelper.py的实现的时候，发现AutoReference和NamespaceInjector，不太理解，查了官方的一些文档，发现这两个使用做document或者collection之间的引用的。

然后pymongo的文档里面说，一般这两个函数是要一起使用才有效果的=)，我修改了下，不过代码我还没实际跑起来，貌似图片上传比较麻烦.....

参考文档：
http://huangz.iteye.com/blog/1196185
